### PR TITLE
Fixed mispelled 'Authorization' in basic_requests

### DIFF
--- a/rocket_snake/basic_requests.py
+++ b/rocket_snake/basic_requests.py
@@ -109,7 +109,7 @@ async def basic_request(loop: asyncio.AbstractEventLoop, api_key: str, timeout_s
                                 "The HTTP response code was 401, which means that your API key wasn't valid.")
                     elif response.status >= 300:
                         # We make sure we don't leak the API key
-                        kwargs["headers"]["Authorisation"] = "Not included in log to prevent leaking."
+                        kwargs["headers"]["Authorization"] = "Not included in log to prevent leaking."
                         raise custom_exceptions.APIBadResponseCodeError(
                                 "The HTTP response code was {0}, which is not a good one. \n"
                                 "The response headers were: \n{6}\n"


### PR DESCRIPTION
Fixes #3 
This was causing the actual api key to be leaked in exceptions caused by
malformed requests.

Signed-off-by: Alex Curtin <alexander.curtin@temple.edu>